### PR TITLE
Fix the atom heuristic selection of basis sizes.

### DIFF
--- a/aiida_siesta/utils/protocols.py
+++ b/aiida_siesta/utils/protocols.py
@@ -288,8 +288,8 @@ class ProtocolManager:
                 card = '\n'
                 for k, v in size_dict.items():
                     card = card + '  {0}  {1} \n'.format(k, v)
-                card = card + '%endblock paobasessizes'
-                basis['%block pao-bases-sizes'] = card
+                card = card + '%endblock paobasissizes'
+                basis['%block pao-basis-sizes'] = card
             if pao_block_dict:
                 card = '\n'
                 for k, v in pao_block_dict.items():


### PR DESCRIPTION
A stupid typo was causing the atom heuristic changes for the basis
sizes to be ineffective. Fixed.