### PR TITLE
Fixed links pointing to the repository.

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,7 +8,7 @@ jobs:
 
     tests:
 
-        if: github.repository == 'albgar/aiida_siesta_plugin'  # Prevent running the builds on forks as well
+        if: github.repository == 'siesta-project/aiida_siesta_plugin'  # Prevent running the builds on forks as well
 
         runs-on: ubuntu-latest
 

--- a/aiida_siesta/docs/index.rst
+++ b/aiida_siesta/docs/index.rst
@@ -13,7 +13,7 @@ The aiida-siesta python package interfaces the SIESTA DFT code
 (http://www.aiida.net).  The package contains: plugins for SIESTA
 itself and for other utility programs, new data structures, and basic
 workflows. It is distributed under the MIT license and available from
-(https://github.com/albgar/aiida_siesta_plugin).
+(https://github.com/siesta-project/aiida_siesta_plugin).
 If you use this package, please cite J. Chem. Phys. **152**, 204108 (2020) 
 (https://doi.org/10.1063/5.0005077).
 

--- a/aiida_siesta/docs/installation.rst
+++ b/aiida_siesta/docs/installation.rst
@@ -12,7 +12,7 @@ In this case, make sure to refer to the appropriate documentation part ("stable"
 
 Because the package is under development, in order to enjoy the most recent features
 one can clone the github repository
-(https://github.com/albgar/aiida_siesta_plugin) and install
+(https://github.com/siesta-project/aiida_siesta_plugin) and install
 from the top level of the plugin directory with::
 
     pip install -e .

--- a/aiida_siesta/docs/plugins/siesta.rst
+++ b/aiida_siesta/docs/plugins/siesta.rst
@@ -14,7 +14,7 @@ Supported Siesta versions
 At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 release, which
 can be found in the development platform (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the 
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 .. _siesta-plugin-inputs:
 

--- a/aiida_siesta/docs/plugins/stm.rst
+++ b/aiida_siesta/docs/plugins/stm.rst
@@ -21,7 +21,7 @@ Supported Siesta versions
 At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 release, 
 which can be found in the development platform (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the      
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 

--- a/aiida_siesta/docs/utils/protocols_system.rst
+++ b/aiida_siesta/docs/utils/protocols_system.rst
@@ -51,7 +51,7 @@ with support for psml pseudopotential. At least **the MaX-1.0 release of Siesta*
 can be found in the development platform
 (https://gitlab.com/siesta-project/siesta), meets this requirement.
 For more up to date info on compatibility, please check the
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 
@@ -119,7 +119,7 @@ peculiarities of particular elements.
   We are working on a more accurate (and expensive) protocol that will provide much better
   values of delta.
   New tests and checks on the *standard_psml* protocol will be added in the aiida-siesta 
-  `wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Protocols-validations>`_.
+  `wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Protocols-validations>`_.
 
 
   

--- a/aiida_siesta/docs/workflows/bandgap.rst
+++ b/aiida_siesta/docs/workflows/bandgap.rst
@@ -22,7 +22,7 @@ At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 relea
 can be found in the development platform
 (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 Inputs

--- a/aiida_siesta/docs/workflows/base.rst
+++ b/aiida_siesta/docs/workflows/base.rst
@@ -37,7 +37,7 @@ At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 relea
 can be found in the development platform
 (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the      
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 

--- a/aiida_siesta/docs/workflows/converger.rst
+++ b/aiida_siesta/docs/workflows/converger.rst
@@ -21,7 +21,7 @@ At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 relea
 can be found in the development platform
 (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the      
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 .. _siesta-converger-inputs:

--- a/aiida_siesta/docs/workflows/eos.rst
+++ b/aiida_siesta/docs/workflows/eos.rst
@@ -41,7 +41,7 @@ At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 relea
 can be found in the development platform
 (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the      
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 

--- a/aiida_siesta/docs/workflows/iterator.rst
+++ b/aiida_siesta/docs/workflows/iterator.rst
@@ -18,7 +18,7 @@ At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 relea
 can be found in the development platform
 (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the      
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 .. _siesta-iterator-inputs:

--- a/aiida_siesta/docs/workflows/seq_converger.rst
+++ b/aiida_siesta/docs/workflows/seq_converger.rst
@@ -18,7 +18,7 @@ At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 relea
 can be found in the development platform
 (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the      
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 

--- a/aiida_siesta/docs/workflows/stm.rst
+++ b/aiida_siesta/docs/workflows/stm.rst
@@ -49,7 +49,7 @@ At least 4.0.1 of the 4.0 series, 4.1-b3 of the 4.1 series and the MaX-1.0 relea
 can be found in the development platform
 (https://gitlab.com/siesta-project/siesta).
 For more up to date info on compatibility, please check the      
-`wiki <https://github.com/albgar/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
+`wiki <https://github.com/siesta-project/aiida_siesta_plugin/wiki/Supported-siesta-versions>`_.
 
 
 

--- a/setup.json
+++ b/setup.json
@@ -1,7 +1,7 @@
 {
     "version": "Dev-post1.1.1",
     "name": "aiida-siesta",
-    "url": "https://github.com/albgar/aiida_siesta_plugin",
+    "url": "https://github.com/siesta-project/aiida_siesta_plugin",
     "keywords": ["aiida", "siesta", "dft"],
     "license": "MIT License",
     "author": "Alberto Garcia, Victor M. Garcia-Suarez, Emanuele Bosoni, Vladimir Dikan, Pol Febrer",


### PR DESCRIPTION
Since we moved the reository of GitHub from "albgar" account,
to "siesta-project" account, all the links pointing to
content in the repository have been updated.