### PR TITLE
Dependencies: temporarily limit upper version of `sqlalchemy`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -19,7 +19,8 @@
 	"aiida_core>=1.3.0,<2.0.0",
 	"ase~=3.18",
 	"seekpath~=1.9,>=1.9.3",
-	"sisl"
+	"sisl",
+	"sqlalchemy<1.4"
     ],
     "extras_require": {
 	"dev": [


### PR DESCRIPTION
The newly released `sqlalchemy==1.4.0` breaks `sqlalchemy-utils` and so
breaks all the tests. Until the latter releases a fix, we have to put an
upper limit on the `sqlalchemy` dependency.